### PR TITLE
Recognizes moduli as coprime if their gcd is constant

### DIFF
--- a/src/ffapl/java/math/crt/PolynomialSimultaneousCongruencesProblem.java
+++ b/src/ffapl/java/math/crt/PolynomialSimultaneousCongruencesProblem.java
@@ -159,7 +159,7 @@ public class PolynomialSimultaneousCongruencesProblem {
         for (int i = 0; i < moduli.size(); i++) {
             for (int j = i+1; j < moduli.size(); j++) {
                 isRunning(thread);
-                if (!gcd(moduli.get(i), moduli.get(j)).isOne()) {
+                if (!gcd(moduli.get(i), moduli.get(j)).isConstant()) {
                     return new int[] {i,j};
                 }
             }


### PR DESCRIPTION
moduli are coprime for polynomials if their gcd is constant (i.e. has degree 0). It does not necessarily have to be exactly "1".