### PR TITLE
RestrictedHashMap --> ASTNodeMessageBroker and removes dangling "}}"

### DIFF
--- a/src/ffapl/FFaplInterpreter.java
+++ b/src/ffapl/FFaplInterpreter.java
@@ -34,7 +34,7 @@ public class FFaplInterpreter extends Thread implements FFaplASTreeConstants, FF
 
   /**
    * @param logger
-   * @param reader 
+   * @param reader
    */
   public FFaplInterpreter(FFaplLogger logger, Reader reader)
   {
@@ -47,7 +47,7 @@ public class FFaplInterpreter extends Thread implements FFaplASTreeConstants, FF
 
   /**
    * @param logger
-   * @param stream 
+   * @param stream
    */
   public FFaplInterpreter(FFaplLogger logger, InputStream stream)
   {
@@ -75,7 +75,7 @@ public class FFaplInterpreter extends Thread implements FFaplASTreeConstants, FF
          //Symbol and Type checking
          _symbolVisit = new FFaplSymbolTypeCheckingVisitor(_symbolTable, _logger, this);
          _symbolVisit.visit(_root, null);
-         //interpret        	
+         //interpret
          _javaInterpreter = new FFaplJavaInterpreterVisitor(_symbolTable, _logger, this);
          _javaInterpreter.visit(_root, null);
      }catch(ParseException pe){
@@ -3092,12 +3092,6 @@ t7 = new FFaplNodeToken(t1);
     finally { jj_save(11, xla); }
   }
 
-  private boolean jj_3_2()
- {
-    if (jj_3R_28()) return true;
-    return false;
-  }
-
   private boolean jj_3_8()
  {
     if (jj_3R_33()) return true;
@@ -3548,6 +3542,12 @@ t7 = new FFaplNodeToken(t1);
     if (jj_scan_token(ECLEFT)) { if (!jj_rescan) trace_return("ECPoint(LOOKAHEAD FAILED)"); return true; }
     if (jj_3R_36()) { if (!jj_rescan) trace_return("ECPoint(LOOKAHEAD FAILED)"); return true; }
     { if (!jj_rescan) trace_return("ECPoint(LOOKAHEAD SUCCEEDED)"); return false; }
+  }
+
+  private boolean jj_3_2()
+ {
+    if (jj_3R_28()) return true;
+    return false;
   }
 
   /** Generated Token Manager. */

--- a/src/ffapl/ffaplParser.jj
+++ b/src/ffapl/ffaplParser.jj
@@ -49,7 +49,7 @@ public class FFaplInterpreter extends Thread implements FFaplASTreeConstants
 		this.disable_tracing();
 		_logger = logger;
 		_interrupted = false;
-		_identTypeMapping = new RestrictedHashMap<String,Type>();
+		_identTypeMapping = new ASTNodeMessageBroker<String,Type>();
   }
 
   /**
@@ -62,7 +62,7 @@ public class FFaplInterpreter extends Thread implements FFaplASTreeConstants
 		this.disable_tracing();
 		_logger = logger;
 		_interrupted = false;
-		_identTypeMapping = new RestrictedHashMap<String,Type>();
+		_identTypeMapping = new ASTNodeMessageBroker<String,Type>();
   }
 
   public FFaplLogger getLogger(){
@@ -105,7 +105,6 @@ public class FFaplInterpreter extends Thread implements FFaplASTreeConstants
 			_logger.log(ILevel.ERROR, (new FFaplException(arguments, ICompilerError.INTERNAL)).getErrorMessage());
     	}*/
   }
-}}
 }
 
 


### PR DESCRIPTION
The class RestrictedHashMap has been renamed to ASTNodeMessageBroker but variables are still declared as RestrictedHashMap. Fixed that. 

Also, dangling "}}" in line 108 of ffaplParser.jj removed.